### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,10 @@ to the project files on the jsDelivr CDN:
 
 ```html
 <!-- CSS -->
-<link rel="stylesheet" href="//cdn.jsdelivr.net/leipzig/latest/leipzig.min.css">
+<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/leipzig@latest/dist/leipzig.min.css">
 
 <!-- JavaScript -->
-<script src="//cdn.jsdelivr.net/leipzig/latest/leipzig.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/leipzig@latest/dist/leipzig.min.js"></script>
 ```
 
 For more information about jsDelivr, you can visit the [jsDelivr
@@ -175,7 +175,7 @@ If you're using [jQuery][], you can use the following script instead:
 ```html
 <html>
   <head>
-    <link rel="stylesheet" href="//cdn.jsdelivr.net/leipzig/latest/leipzig.min.css">
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/leipzig@latest/dist/leipzig.min.css">
   </head>
   <body>
     <div data-gloss>
@@ -183,7 +183,7 @@ If you're using [jQuery][], you can use the following script instead:
       <p>DET.NOM.N.SG example</p>
       <p>‘An example’</p>
     </div>
-    <script src="//cdn.jsdelivr.net/leipzig/latest/leipzig.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/leipzig@latest/dist/leipzig.min.js"></script>
     <script>
       document.addEventListener('DOMContentLoaded', function() {
         Leipzig().gloss();


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/leipzig.

Feel free to ping me if you have any questions regarding this change.